### PR TITLE
Fix: Reinforce Sidebar/Footer theming using CSS variables

### DIFF
--- a/src/components/layout/Footer.module.css
+++ b/src/components/layout/Footer.module.css
@@ -7,12 +7,12 @@
   transition-duration: 200ms;
 }
 .footerBaseLight {
-  background-color: #f3f4f6; /* bg-gray-100 */
-  color: #374151; /* text-gray-700 */
+  background-color: var(--background); /* Use CSS variable */
+  color: var(--foreground); /* Use CSS variable */
 }
 .footerBaseDark {
-  background-color: #111827; /* bg-gray-900 */
-  color: #d1d5db; /* text-gray-300, slightly lighter than pure white for better aesthetics on dark */
+  background-color: var(--background); /* Use CSS variable */
+  color: var(--foreground); /* Use CSS variable */
 }
 
 .container {
@@ -86,8 +86,8 @@
   font-size: 1.25rem; /* text-xl */
   font-weight: 700; /* font-bold */
 }
-.logoTitleLight { color: #111827; } /* text-gray-900 */
-.logoTitleDark { color: white; }
+.logoTitleLight { color: #111827; } /* text-gray-900, specific */
+.logoTitleDark { color: white; } /* specific */
 
 .logoSubtitle {
   font-size: 0.875rem; /* text-sm */
@@ -99,6 +99,8 @@
   font-size: 0.875rem; /* text-sm */
   line-height: 1.625; /* leading-relaxed */
 }
+/* Inherits color from .footerBaseLight / .footerBaseDark or more specific if needed */
+/* For example, if it needs to be slightly lighter than var(--foreground) in light mode: */
 .descriptionTextLight { color: #4b5563; } /* text-gray-600 */
 .descriptionTextDark { color: #d1d5db; } /* text-gray-300 */
 
@@ -119,18 +121,18 @@
 }
 .socialIconLinkLight {
   background-color: #e5e7eb; /* bg-gray-200 */
-  color: #4b5563; /* Icon color for light bg */
+  color: #4b5563;
 }
 .socialIconLinkLight:hover {
-  background-color: #3b82f6; /* hover:bg-blue-600 */
+  background-color: #3b82f6;
   color: white;
 }
 .socialIconLinkDark {
   background-color: #1f2937; /* bg-gray-800 */
-  color: #d1d5db; /* Icon color for dark bg */
+  color: #d1d5db;
 }
 .socialIconLinkDark:hover {
-  background-color: #2563eb; /* hover:bg-blue-600 */
+  background-color: #2563eb;
   color: white;
 }
 .socialIcon {
@@ -144,8 +146,8 @@
   font-weight: 600; /* font-semibold */
   margin-bottom: 1rem; /* mb-4 */
 }
-.linksSectionTitleLight { color: #1f2937; } /* text-gray-800 */
-.linksSectionTitleDark { color: white; }
+.linksSectionTitleLight { color: #1f2937; } /* text-gray-800, specific */
+.linksSectionTitleDark { color: white; } /* specific */
 
 .linksList {
   display: flex;
@@ -190,8 +192,9 @@
   gap: 0.5rem; /* space-x-2 */
   font-size: 0.875rem; /* text-sm */
 }
-.contactInfoItemLight { color: #4b5563; } /* text-gray-600 */
-.contactInfoItemDark { color: #d1d5db; } /* text-gray-300 */
+/* Inherits color from .footerBaseLight / .footerBaseDark or specific if needed */
+.contactInfoItemLight { color: #4b5563; }
+.contactInfoItemDark { color: #d1d5db; }
 .contactInfoIcon {
   height: 1rem; /* h-4 */
   width: 1rem; /* w-4 */
@@ -225,8 +228,8 @@
   font-size: 0.875rem; /* text-sm */
   font-weight: 500; /* font-medium */
 }
-.protectedDataTitleLight { color: #1f2937; } /* text-gray-800 */
-.protectedDataTitleDark { color: white; }
+.protectedDataTitleLight { color: #1f2937; } /* text-gray-800, specific */
+.protectedDataTitleDark { color: white; } /* specific */
 
 .protectedDataText {
   font-size: 0.75rem; /* text-xs */

--- a/src/components/layout/Sidebar.module.css
+++ b/src/components/layout/Sidebar.module.css
@@ -11,16 +11,18 @@
   box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -2px rgb(0 0 0 / 0.05); /* shadow-lg */
   display: flex;
   flex-direction: column;
-  transition-property: background-color, border-color;
+  transition-property: background-color, border-color, color; /* Added color to transition */
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 200ms;
 }
 .sidebarBaseLight {
-  background-color: white;
+  background-color: var(--background); /* Use CSS variable */
+  color: var(--foreground); /* Use CSS variable */
   border-right: 1px solid #e5e7eb; /* border-gray-200 */
 }
 .sidebarBaseDark {
-  background-color: #111827; /* bg-gray-900, example dark bg */
+  background-color: var(--background); /* Use CSS variable */
+  color: var(--foreground); /* Use CSS variable */
   border-right: 1px solid #374151; /* border-gray-700, example dark border */
 }
 @media (min-width: 1024px) { /* lg: */
@@ -84,10 +86,10 @@
   font-weight: 700; /* font-bold */
 }
 .logoTitleLight {
-  color: #111827; /* text-gray-900 */
+  color: #111827; /* text-gray-900, specific, not var(--foreground) */
 }
 .logoTitleDark {
-  color: #f3f4f6; /* text-gray-100 */
+  color: #f3f4f6; /* text-gray-100, specific, not var(--foreground) */
 }
 .logoSubtitle {
   font-size: 0.75rem; /* text-xs */
@@ -142,10 +144,10 @@
   white-space: nowrap;
 }
 .userNameLight {
-  color: #111827; /* text-gray-900 */
+  color: #111827; /* text-gray-900, specific */
 }
 .userNameDark {
-  color: #f3f4f6; /* text-gray-100 */
+  color: #f3f4f6; /* text-gray-100, specific */
 }
 .userStatus {
   font-size: 0.75rem; /* text-xs */
@@ -189,13 +191,13 @@
   transition-duration: 200ms;
 }
 .menuItemLink.subItem { /* For level > 0 */
-  margin-left: 1rem; /* ml-4, but this is margin on the motion.div, so apply to link itself */
-  padding-left: 2rem; /* pl-8 original was on link, this combines margin and padding */
+  margin-left: 1rem;
+  padding-left: 2rem;
 }
 
 /* Light theme menu items */
 .menuItemLinkLight {
-  color: #374151; /* text-gray-700 */
+  color: #374151; /* text-gray-700, specific for menu items, could be var(--foreground-muted) if available */
 }
 .menuItemLinkLight:hover {
   background-color: #f3f4f6; /* hover:bg-gray-100 */
@@ -204,9 +206,7 @@
 .menuItemActiveLight {
   background-color: #eff6ff; /* bg-blue-50 */
   color: #1d4ed8; /* text-blue-700 */
-  /* Tailwind's border-r-2 border-blue-600 might need specific handling if not on all sides */
-  /* For simplicity, using a distinct background for active might be enough, or add border here */
-  box-shadow: inset -2px 0 0 0 #2563eb; /* Simulates border-r-2 border-blue-600 */
+  box-shadow: inset -2px 0 0 0 #2563eb;
 }
 .menuItemIconLight {
   color: #6b7280; /* text-gray-500 */
@@ -217,22 +217,22 @@
 
 /* Dark theme menu items */
 .menuItemLinkDark {
-  color: #d1d5db; /* text-gray-300 */
+  color: #d1d5db; /* text-gray-300, specific for menu items */
 }
 .menuItemLinkDark:hover {
   background-color: #374151; /* hover:bg-gray-700 */
   color: #f9fafb; /* hover:text-gray-100 */
 }
 .menuItemActiveDark {
-  background-color: #2b3649; /* Example: a darker blue/gray for active dark */
-  color: #60a5fa; /* Example: lighter blue for active text dark */
-  box-shadow: inset -2px 0 0 0 #3b82f6; /* Simulates border-r-2 border-blue-500 */
+  background-color: #2b3649;
+  color: #60a5fa;
+  box-shadow: inset -2px 0 0 0 #3b82f6;
 }
 .menuItemIconDark {
   color: #9ca3af; /* text-gray-400 */
 }
 .menuItemIconActiveDark {
-  color: #60a5fa; /* Example: lighter blue for active icon dark */
+  color: #60a5fa;
 }
 
 
@@ -261,7 +261,7 @@
   color: #166534; /* text-green-700 */
 }
 .badgeNovoDark {
-  background-color: #166534; /* bg-green-800 or similar */
+  background-color: #166534;
   color: #a7f3d0; /* text-green-300 */
 }
 .badgeIALight {
@@ -269,7 +269,7 @@
   color: #5b21b6; /* text-purple-700 */
 }
 .badgeIADark {
-  background-color: #5b21b6; /* bg-purple-800 or similar */
+  background-color: #5b21b6;
   color: #c4b5fd; /* text-purple-300 */
 }
 
@@ -311,12 +311,10 @@
   border-radius: 0.375rem; /* rounded-lg */
 }
 .footerCardLight {
-  /* bg-gradient-to-r from-blue-50 to-purple-50 */
   background-image: linear-gradient(to right, #eff6ff, #f5f3ff);
 }
 .footerCardDark {
-  /* Example dark gradient or solid color */
-  background-image: linear-gradient(to right, #1e293b, #28233e); /* Darker blue/purple gradient */
+  background-image: linear-gradient(to right, #1e293b, #28233e);
 }
 .footerCardContent {
   display: flex;
@@ -326,7 +324,7 @@
 .footerIconContainer {
   width: 2.5rem; /* w-10 */
   height: 2.5rem; /* h-10 */
-  background-image: linear-gradient(to bottom right, #3b82f6, #8b5cf6); /* from-blue-500 to-purple-600 */
+  background-image: linear-gradient(to bottom right, #3b82f6, #8b5cf6);
   border-radius: 0.375rem; /* rounded-lg */
   display: flex;
   align-items: center;
@@ -346,10 +344,10 @@
   font-weight: 500; /* font-medium */
 }
 .footerTitleLight {
-  color: #111827; /* text-gray-900 */
+  color: #111827; /* text-gray-900, specific */
 }
 .footerTitleDark {
-  color: #f3f4f6; /* text-gray-100 */
+  color: #f3f4f6; /* text-gray-100, specific */
 }
 .footerSubtitle {
   font-size: 0.75rem; /* text-xs */


### PR DESCRIPTION
This commit updates the Sidebar and Footer CSS modules to explicitly use global CSS variables (`var(--background)`, `var(--foreground)`) for their base background and text colors.

This change aims to make the components more directly responsive to the theme changes managed by `ThemeContext.tsx` and `globals.css`, further ensuring that the theme selection correctly applies the intended base styles.

Other specific styling within the components (e.g., for titles, accents) remains as previously defined with explicit color codes where appropriate for the design.