### PR TITLE
feat: Add GitHub Action for deploying to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,65 @@
+name: Deploy Next.js to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # Or your default branch
+
+permissions:
+  contents: write # Needed to push to gh-pages branch
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.x' # Specify your Node.js version
+
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        # This assumes your build script is `next build && next export` or just `next build`
+        # if `output: 'export'` is set in next.config.js.
+        # The `next export` command is implicitly handled by `output: 'export'`.
+        run: npm run build
+        env:
+          # NEXT_PUBLIC_BASE_PATH: /your-repo-name # Uncomment if deploying to <username>.github.io/your-repo-name
+          # Add any other build-time environment variables here if needed
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out
+          # publish_branch: gh-pages # Default is gh-pages
+          # user_name: 'github-actions[bot]' # Default
+          # user_email: 'github-actions[bot]@users.noreply.github.com' # Default
+          # commit_message: ${{ github.event.head_commit.message }} # Default
+          # cname: your.custom.domain.com # Uncomment and set if you have a custom domain
+          # If your custom domain is managed through GitHub Pages settings, CNAME file is often not needed here.
+          # However, if you want the action to create/update it, you can.
+          # For a repository like <username>/<username>.github.io, a CNAME is usually placed in the root of the source branch.
+          # For a project site deployed to gh-pages, the action can create it in the publish_dir.
+          # Given the user just set up a custom domain, they might have already configured it in repo settings.
+          # If they want the action to manage the CNAME file in the gh-pages branch:
+          # cname: ${{ vars.YOUR_CUSTOM_DOMAIN_VARIABLE_FROM_REPO_SETTINGS }} # Example using repo variable
+          # Or hardcode if preferred: cname: yourdomain.com
+          # For now, assume CNAME is handled via GitHub Pages settings or already in source repo if needed.
+          # The action will deploy the content of ./out to the root of the gh-pages branch.
+          # GitHub Pages will then serve this branch. If a custom domain is set in repo settings,
+          # it should point to this content.
+```

--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,9 @@ const nextConfig: NextConfig = {
   reactStrictMode: true,
   poweredByHeader: false,
 
+  // Output mode for static export
+  output: 'export',
+
   // Otimizações experimentais
   experimental: {
     optimizePackageImports: [
@@ -23,12 +26,13 @@ const nextConfig: NextConfig = {
 
   // Configuração otimizada de imagens
   images: {
+    unoptimized: true, // Required for static export if not using a custom image loader
     formats: ['image/webp', 'image/avif'],
     deviceSizes: [320, 640, 768, 1024, 1280, 1536, 1920, 2560],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384, 512],
     minimumCacheTTL: 31536000, // 1 year
     dangerouslyAllowSVG: true,
-    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
+    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;", // This CSP is for <img src> inlined SVGs, not the main site CSP
     domains: ['res.cloudinary.com', 'images.unsplash.com', 'firebasestorage.googleapis.com'],
   },
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "export": "next export",
     "lint": "next lint",
     "lint:fix": "next lint --fix",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,css,md}\"",


### PR DESCRIPTION
This commit introduces a GitHub Action workflow to automate the build and deployment of the Next.js application to GitHub Pages.

It also includes necessary configuration changes to enable static HTML export (`output: 'export'`) and disable server-side image optimization (`images.unoptimized = true`) in `next.config.ts`, which are required for deploying to a static host like GitHub Pages.

An `export` script has also been added to `package.json` for completeness.

The workflow is configured to:
- Trigger on push to the `main` branch.
- Build the Next.js application (including static export to the `out/` dir).
- Deploy the contents of the `out/` directory to the `gh-pages` branch.

You will need to configure your GitHub Pages settings to serve from the `gh-pages` branch after this Action runs successfully.