### PR TITLE
Fix: Correct IP address retrieval in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -63,7 +63,7 @@ export function middleware(request: NextRequest) {
   }
 
   // Basic rate limiting and suspicious activity logging (can be expanded)
-  const ip = request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || request.ip || 'unknown';
+  const ip = request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || (request.geo?.ip) || 'unknown';
   const userAgent = request.headers.get('user-agent') || 'unknown';
 
   if (userAgent.includes('bot') && !userAgent.includes('Googlebot') && !userAgent.includes('bingbot')) {


### PR DESCRIPTION
Updates the IP address retrieval logic in `src/middleware.ts` to resolve a TypeScript type error: "Property 'ip' does not exist on type 'NextRequest'".

The problematic `request.ip` has been replaced with `request.geo?.ip`, using optional chaining for safe access. This leverages the `request.geo` object provided by environments like Vercel Edge Functions for more accurate geolocation data, while still falling back to standard headers like 'x-forwarded-for' and 'x-real-ip'.

This change should allow your project to build successfully.